### PR TITLE
Issue #21 Feature Request: Route Guarding 

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -10347,6 +10347,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
+    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/application/package.json
+++ b/application/package.json
@@ -11,6 +11,7 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
     "redux": "^4.0.1",
+    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0"
   },
   "scripts": {

--- a/application/src/App.js
+++ b/application/src/App.js
@@ -1,14 +1,17 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react'
 import AppRouter from './router/appRouter';
-import store from './redux/store';
+import {store, persistor} from './redux/store';
 import './App.css';
 
 class App extends Component {
   render() {
     return (
       <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
         <AppRouter />
+      </PersistGate>
       </Provider>
     )
   }

--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux'; 
 import { loginUser } from '../../../redux/actions/authActions'
 
+const mapStateToProps = (state) => ({
+  auth: state.auth,
+})
+
 const mapActionsToProps = dispatch => ({
   commenceLogin(email, password) {
     dispatch(loginUser(email, password))
@@ -17,7 +21,7 @@ class LoginForm extends Component {
   login(e) {
     e.preventDefault();
     this.props.commenceLogin(this.state.email, this.state.password);
-    this.props.onLogin();
+    console.log('commenceLogin finishes')
   }
 
   onChange(key, val) {
@@ -25,6 +29,10 @@ class LoginForm extends Component {
   }
 
   render() {
+    if (this.props.auth.token === '12345luggage') {
+      console.log('hits this.props.auth.token === 12345luggage')
+      return this.props.onLogin();
+    } 
     return (
       <form>
         <div className="form-group">
@@ -43,4 +51,4 @@ class LoginForm extends Component {
   }
 }
 
-export default connect(null, mapActionsToProps)(LoginForm);
+export default connect(mapStateToProps, mapActionsToProps)(LoginForm);

--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -21,7 +21,6 @@ class LoginForm extends Component {
   login(e) {
     e.preventDefault();
     this.props.commenceLogin(this.state.email, this.state.password);
-    console.log('commenceLogin finishes')
   }
 
   onChange(key, val) {
@@ -30,7 +29,6 @@ class LoginForm extends Component {
 
   render() {
     if (this.props.auth.token === '12345luggage') {
-      console.log('hits this.props.auth.token === 12345luggage')
       return this.props.onLogin();
     } 
     return (

--- a/application/src/components/login/login.js
+++ b/application/src/components/login/login.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import {Redirect} from 'react-router-dom';
 import LoginForm from './login-form/loginForm';
 import './login.css';
 
@@ -9,7 +10,7 @@ class Login extends Component {
       <div className="main-body">
         <h1 className="text-center">Login Screen</h1>
         <div className="d-flex justify-content-center mt-5">
-          <LoginForm onLogin={() => {this.props.history.push('/view-orders')}}/>
+          <LoginForm onLogin={() => <Redirect to='/view-orders'/>}/>
         </div>
       </div>
     )

--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import {Redirect} from 'react-router-dom';
 import { Template } from '../../components';
 import { connect } from 'react-redux';
 import { SERVER_IP } from '../../private';
@@ -47,6 +48,9 @@ class OrderForm extends Component {
     }
 
     render() {
+        if (this.props.auth.token !== '12345luggage') {
+            return <Redirect to="/login"/>
+        }
         return (
             <Template>
                 <div className="form-wrapper">

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -67,4 +67,4 @@ class ViewOrders extends Component {
     }
 }
 
-export default connect(mapStateToProps, null)(ViewOrders);
+export default connect(mapStateToProps)(ViewOrders);

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -10,13 +10,15 @@ const mapStateToProps = (state) => ({
 })
 
 class ViewOrders extends Component {
-    state = {
-        orders: []
-    }
+        controller = new AbortController();
+        signal = this.controller.signal;
+        state = {
+            orders: []
+        }
 
 
     componentDidMount() {
-        fetch(`${SERVER_IP}/api/current-orders`)
+        fetch(`${SERVER_IP}/api/current-orders`, {signal: this.signal})
             .then(response => response.json())
             .then(response => {
                 if(response.success) {
@@ -24,7 +26,13 @@ class ViewOrders extends Component {
                 } else {
                     console.log('Error getting orders');
                 }
-            });
+            }).catch(() => {
+                console.log('request for current orders cancelled!');
+            })
+    }
+
+    componentWillUnmount() {
+        this.controller.abort();
     }
 
     render() {

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,12 +1,19 @@
 import React, { Component } from 'react';
+import {Redirect} from 'react-router-dom';
+import { connect } from 'react-redux';
 import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import './viewOrders.css';
+
+const mapStateToProps = (state) => ({
+    auth: state.auth,
+})
 
 class ViewOrders extends Component {
     state = {
         orders: []
     }
+
 
     componentDidMount() {
         fetch(`${SERVER_IP}/api/current-orders`)
@@ -21,6 +28,9 @@ class ViewOrders extends Component {
     }
 
     render() {
+        if (this.props.auth.token !== '12345luggage') {
+            return <Redirect to="/login"/>
+        }
         return (
             <Template>
                 <div className="container-fluid">
@@ -49,4 +59,4 @@ class ViewOrders extends Component {
     }
 }
 
-export default ViewOrders;
+export default connect(mapStateToProps, null)(ViewOrders);

--- a/application/src/redux/store.js
+++ b/application/src/redux/store.js
@@ -1,7 +1,16 @@
 import { createStore, applyMiddleware } from 'redux';
 import ReduxThunk from 'redux-thunk';
+import { persistStore, persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage' 
 import reducers from './reducers';
 
-const store = createStore(reducers, {}, applyMiddleware(ReduxThunk));
+const persistConfig = {
+  key: 'root',
+  storage,
+}
 
-export default store;
+const persistedReducer = persistReducer(persistConfig, reducers)
+
+export const store = createStore(persistedReducer, {}, applyMiddleware(ReduxThunk));
+export const persistor = persistStore(store);
+


### PR DESCRIPTION
Redirects user to login page when the user is not logged in on view-order and order-form pages.

I Considered 
1. placing the routing logic from view-order and order-form in the Template or Nav component to reduce code duplication, but decided not to do so since that could make those components less reusable.
2. using a helper function to store the logic to redirect user to login page, but the function would've been so short it wouldn't save me any lines of code. I'd still consider this approach in the future if the app got bigger and I noticed I had to change the route these components redirect to a bunch of times and I wanted to do that by just changing the route name once.

In case this disclaimer is necessary, I recognize auth in a production app would be much more complex. Since the back-end only returned one token, its an interview project and the repo is titled react-challenge-project, I interpreted the task to be handling the routing appropriately.